### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+install:
+- ./mvn.sh test install
+- ./mvnassembly.sh


### PR DESCRIPTION
Build currently [fails](https://travis-ci.org/krichter722/robocode/builds/157937466) due to missing `DISPLAY` variable which isn't mentioned in [build instructions](http://robowiki.net/wiki/Robocode/Developers_Guide_for_building_Robocode). If you tell me how to build on a CI service which is a very crucial tool, I'll update the PR.
