### PR TITLE
Add support for loading classes having invokedynamic instructions

### DIFF
--- a/robocode.host/src/main/java/net/sf/robocode/host/security/ClassAnalyzer.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/security/ClassAnalyzer.java
@@ -36,6 +36,9 @@ class ClassAnalyzer {
 	private final static byte CONSTANT_Double = 6;
 	private final static byte CONSTANT_NameAndType = 12;
 	private final static byte CONSTANT_Utf8 = 1;
+	private final static byte CONSTANT_MethodHandle = 15;
+	private final static byte CONSTANT_MethodType = 16;
+	private final static byte CONSTANT_InvokeDynamic = 18;
 
 	/**
 	 * ClassAnalyzer constructor comment.
@@ -110,6 +113,9 @@ class ClassAnalyzer {
 			 CONSTANT_Double  6
 			 CONSTANT_NameAndType  12
 			 CONSTANT_Utf8  1
+			 CONSTANT_MethodHandle	15
+			 CONSTANT_MethodType	16
+			 CONSTANT_InvokeDynamic	18
 			 */
 
 
@@ -231,6 +237,46 @@ class ClassAnalyzer {
 						strings[i] = utf8_string;
 					}
 					break;
+
+
+				/*
+				 CONSTANT_MethodHandle_info {
+				 u1 tag;
+				 u1 reference_kind;
+				 u2 reference_index;
+				}
+				 */
+				case CONSTANT_MethodHandle: {
+						in.readByte();
+						in.readShort();
+					}
+					break;
+
+				/*
+				 CONSTANT_MethodType_info {
+				 u1 tag;
+				 u2 descriptor_index;
+				 */
+				case CONSTANT_MethodType: {
+						in.readShort();
+					}
+					break;
+
+				/*
+				 CONSTANT_InvokeDynamic_info {
+				 u1 tag;
+				 u2 bootstrap_method_attr_index;
+				 u2 name_and_type_index;
+				 */
+				case CONSTANT_InvokeDynamic: {
+						in.readShort();
+						in.readShort();
+					}
+					break;
+
+				default: {
+						throw new IllegalStateException("Unknown constant_item tag=" + tag);
+					}
 				} // switch
 			} // for i
 		} catch (IOException e) {


### PR DESCRIPTION
Fix ClassAnalyzer to hop over MethodHandle, MethodType and InvokeDynamic
constant pool entries, otherwise the constant pool reading will fail,
possibly producing a NPE.
