### PR TITLE
Bug fix: .NET plugin unexpectedly accesses SMB and FTP when searching…

### DIFF
--- a/plugins/dotnet/robocode.dotnet.nhost/src/host/seed/AppDomainSeed.cs
+++ b/plugins/dotnet/robocode.dotnet.nhost/src/host/seed/AppDomainSeed.cs
@@ -126,7 +126,7 @@ namespace net.sf.robocode.dotnet.host.seed
                 {
                     if (Reflection.CheckInterfaces(type) != RobotTypeN.INVALID)
                     {
-                        sb.Append("file://");
+                        sb.Append("file:///");
                         sb.Append(robotAssemblyFileName);
                         sb.Append("!/");
                         sb.Append(type.FullName);


### PR DESCRIPTION
… for robots

When Robocode launches, .NET plugin searches for robots by opening
a connection to a URI like file://C:/robots/robot.dll!/hoge.fuga that is
considered as a UNC path with the hostname "C".  Because Windows tries
a couple of protocols to connect to it, Robocode startup can be extremely
delayed, especially the hostname "C" is found but invalid for SMB/FTP.

The fix is to add a prefix "file:///" instead of "file://".  This ensures
that the URI has an empty hostname and it's not considered as UNC.