### PR TITLE
Fix codesize related logic

### DIFF
--- a/plugins/dotnet/robocode.dotnet.content/.classpath
+++ b/plugins/dotnet/robocode.dotnet.content/.classpath
@@ -15,7 +15,7 @@
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.core/1.9.3.0/robocode.core-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.repository/1.9.3.0/robocode.repository-1.9.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/jni4net/jni4net.j/0.8.7.0/jni4net.j-0.8.7.0.jar"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>

--- a/plugins/dotnet/robocode.dotnet.distribution/.classpath
+++ b/plugins/dotnet/robocode.dotnet.distribution/.classpath
@@ -12,7 +12,7 @@
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.core/1.9.3.0/robocode.core-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.repository/1.9.3.0/robocode.repository-1.9.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/jni4net/jni4net.j/0.8.7.0/jni4net.j-0.8.7.0.jar"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java">
 		<attributes>

--- a/plugins/dotnet/robocode.dotnet.host/.classpath
+++ b/plugins/dotnet/robocode.dotnet.host/.classpath
@@ -22,7 +22,7 @@
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.core/1.9.3.0/robocode.core-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.repository/1.9.3.0/robocode.repository-1.9.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/jni4net/jni4net.j/0.8.7.0/jni4net.j-0.8.7.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/junit/junit/4.11/junit-4.11.jar"/>
 	<classpathentry kind="var" path="M2_REPO/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"/>

--- a/plugins/dotnet/robocode.dotnet.tests/.classpath
+++ b/plugins/dotnet/robocode.dotnet.tests/.classpath
@@ -22,7 +22,7 @@
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.host/1.9.3.0/robocode.host-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.battle/1.9.3.0/robocode.battle-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.repository/1.9.3.0/robocode.repository-1.9.3.0.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.samples/1.9.3.0/robocode.samples-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.tests/1.9.3.0/robocode.tests-1.9.3.0.jar"/>
 	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/robocode.tests.robots/1.9.3.0/robocode.tests.robots-1.9.3.0.jar"/>

--- a/robocode.battle/.classpath
+++ b/robocode.battle/.classpath
@@ -16,7 +16,7 @@
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>
 	<classpathentry kind="src" path="/robocode.host"/>
 	<classpathentry kind="src" path="/robocode.repository"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>

--- a/robocode.content/src/main/resources/meleerumble.bat
+++ b/robocode.content/src/main/resources/meleerumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx1024M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xmx1024M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt

--- a/robocode.content/src/main/resources/meleerumble.bat
+++ b/robocode.content/src/main/resources/meleerumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx1024M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xmx1024M -cp libs/robocode.jar;libs/roborumble.jar;libs/bcel-6.2.jar;libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt

--- a/robocode.content/src/main/resources/meleerumble.command
+++ b/robocode.content/src/main/resources/meleerumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=MeleeRumble -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=MeleeRumble -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/meleerumble.command
+++ b/robocode.content/src/main/resources/meleerumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=MeleeRumble -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=MeleeRumble -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/meleerumble.sh
+++ b/robocode.content/src/main/resources/meleerumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/meleerumble.sh
+++ b/robocode.content/src/main/resources/meleerumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
+java -Xmx1024M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/meleerumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/roborumble.bat
+++ b/robocode.content/src/main/resources/roborumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/bcel-6.2.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt

--- a/robocode.content/src/main/resources/roborumble.bat
+++ b/robocode.content/src/main/resources/roborumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.1.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt

--- a/robocode.content/src/main/resources/roborumble.command
+++ b/robocode.content/src/main/resources/roborumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=RoboRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=RoboRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/roborumble.command
+++ b/robocode.content/src/main/resources/roborumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=RoboRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=RoboRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/roborumble.sh
+++ b/robocode.content/src/main/resources/roborumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/roborumble.sh
+++ b/robocode.content/src/main/resources/roborumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/roborumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/teamrumble.bat
+++ b/robocode.content/src/main/resources/teamrumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.1.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt

--- a/robocode.content/src/main/resources/teamrumble.bat
+++ b/robocode.content/src/main/resources/teamrumble.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/bcel-6.2.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt

--- a/robocode.content/src/main/resources/teamrumble.command
+++ b/robocode.content/src/main/resources/teamrumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=TeamRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=TeamRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/teamrumble.command
+++ b/robocode.content/src/main/resources/teamrumble.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=TeamRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=TeamRumble -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/teamrumble.sh
+++ b/robocode.content/src/main/resources/teamrumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/teamrumble.sh
+++ b/robocode.content/src/main/resources/teamrumble.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/teamrumble.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/twinduel.bat
+++ b/robocode.content/src/main/resources/twinduel.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.1.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt

--- a/robocode.content/src/main/resources/twinduel.bat
+++ b/robocode.content/src/main/resources/twinduel.bat
@@ -6,4 +6,4 @@
 @REM https://robocode.sourceforge.io/license/epl-v10.html
 @REM
 
-java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xmx512M -cp libs/robocode.jar;libs/roborumble.jar;libs/bcel-6.2.jar;libs/codesize-1.2.jar; -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt

--- a/robocode.content/src/main/resources/twinduel.command
+++ b/robocode.content/src/main/resources/twinduel.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=TwinDuel -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=TwinDuel -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/twinduel.command
+++ b/robocode.content/src/main/resources/twinduel.command
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xdock:icon=roborumble.ico -Xdock:name=TwinDuel -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xdock:icon=roborumble.ico -Xdock:name=TwinDuel -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/twinduel.sh
+++ b/robocode.content/src/main/resources/twinduel.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/bcel-6.2.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
 cd "${pwd}"

--- a/robocode.content/src/main/resources/twinduel.sh
+++ b/robocode.content/src/main/resources/twinduel.sh
@@ -9,5 +9,5 @@
 
 pwd=`pwd`
 cd "${0%/*}"
-java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.1.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
+java -Xmx512M -cp libs/robocode.jar:libs/roborumble.jar:libs/codesize-1.2.jar -XX:+IgnoreUnrecognizedVMOptions "--add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED" "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" "--add-opens=java.desktop/sun.awt=ALL-UNNAMED" roborumble.RoboRumbleAtHome ./roborumble/twinduel.txt
 cd "${pwd}"

--- a/robocode.distribution/.classpath
+++ b/robocode.distribution/.classpath
@@ -7,7 +7,7 @@
 	</classpathentry>
 	<classpathentry kind="src" path="/robocode.api"/>
 	<classpathentry kind="src" path="/robocode.roborumble"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" path="/robocode.battle"/>
 	<classpathentry kind="src" path="/robocode.core"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>

--- a/robocode.repository/.classpath
+++ b/robocode.repository/.classpath
@@ -14,7 +14,7 @@
 	<classpathentry kind="src" path="/robocode.api"/>
 	<classpathentry kind="src" path="/robocode.core"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>

--- a/robocode.roborumble/.classpath
+++ b/robocode.roborumble/.classpath
@@ -12,7 +12,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="/robocode.api"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" path="/robocode.battle"/>
 	<classpathentry kind="src" path="/robocode.core"/>
 	<classpathentry kind="var" path="M2_REPO/org/picocontainer/picocontainer/2.14.2/picocontainer-2.14.2.jar"/>

--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/CompetitionsSelector.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/CompetitionsSelector.java
@@ -40,7 +40,7 @@ public class CompetitionsSelector {
 		sizes = getProperties(sizesfile);
 	}
 
-	public boolean checkCompetitorForSize(String botName, long maxSize) {
+	public Boolean checkCompetitorForSize(String botName, long maxSize) {
 		String name = botName.replace(' ', '_');
 
 		// Read sizes
@@ -62,13 +62,17 @@ public class CompetitionsSelector {
 			}
 		}
 
-		// If the file needs update, then save the file
-		if (fileNeedsUpdate && codeSize > 0) {
-			storeProperties(sizes, sizesfile, "Bots code size");
-		}
+		if (codeSize > 0) {
+			// If the file needs update, then save the file
+			if (fileNeedsUpdate) {
+				storeProperties(sizes, sizesfile, "Bots code size");
+			}
 
-		// Check the code size
-		return (codeSize < maxSize); // Bug-362
+			// Check the code size
+			return (codeSize < maxSize); // Bug-362
+		} else {
+			return null;
+		}
 	}
 
 	public boolean checkCompetitorsForSize(String bot1, String bot2, long maxsize) {

--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/netengine/BotsDownload.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/netengine/BotsDownload.java
@@ -9,6 +9,7 @@ package net.sf.robocode.roborumble.netengine;
 
 
 import net.sf.robocode.io.Logger;
+import net.sf.robocode.repository.CodeSizeCalculator;
 import net.sf.robocode.roborumble.battlesengine.CompetitionsSelector;
 import static net.sf.robocode.roborumble.netengine.FileTransfer.DownloadStatus;
 import static net.sf.robocode.roborumble.util.ExcludesUtil.*;
@@ -350,7 +351,15 @@ public class BotsDownload {
 
 		// Check the bot and save it into the repository
 
+		Integer codeSize;
+
 		if (checkJarFile(tempFileName, botname)) {
+			codeSize = CodeSizeCalculator.getJarFileCodeSize(new File(tempFileName));
+			if (codeSize == null) {
+				System.out.println("Unable to calc codesize for " + tempFileName);
+				return false;
+			}
+
 			if (!FileTransfer.copy(tempFileName, repositoryFileName)) {
 				System.out.println("Unable to copy " + tempFileName + " into the repository");
 				return false;
@@ -360,7 +369,7 @@ public class BotsDownload {
 			return false;
 		}
 
-		System.out.println("Downloaded " + botname + " into " + repositoryFileName);
+		System.out.println("Downloaded " + botname + " into " + repositoryFileName + " (Codesize: " + codeSize + ")");
 		return true;
 	}
 

--- a/robocode.tests/.classpath
+++ b/robocode.tests/.classpath
@@ -27,7 +27,7 @@
 	<classpathentry kind="src" path="/robocode.host"/>
 	<classpathentry kind="src" path="/robocode.battle"/>
 	<classpathentry kind="src" path="/robocode.repository"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/robocode.ui.editor/.classpath
+++ b/robocode.ui.editor/.classpath
@@ -18,7 +18,7 @@
 	<classpathentry kind="src" path="/robocode.battle"/>
 	<classpathentry kind="src" path="/robocode.host"/>
 	<classpathentry kind="src" path="/robocode.repository"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" path="/robocode.sound"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>

--- a/robocode.ui/.classpath
+++ b/robocode.ui/.classpath
@@ -22,7 +22,7 @@
 	<classpathentry kind="src" path="/robocode.battle"/>
 	<classpathentry kind="src" path="/robocode.host"/>
 	<classpathentry kind="src" path="/robocode.repository"/>
-	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.1/codesize-1.1.jar"/>
+	<classpathentry kind="var" path="M2_REPO/net/sf/robocode/codesize/1.2/codesize-1.2.jar"/>
 	<classpathentry kind="src" path="/robocode.sound"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>


### PR DESCRIPTION
1. codesize calculation error is no longer silenced (and polluting roborumble) in roborumble@home. 
2. -cp options (codesize and bcel) in roborumble.sh etc. is fixed for roborumble to work properly. 
3. codesize is ensured when robot is downloaded to prevent polluting robot repository. 
