### PR TITLE
MouseEvent returning wrong position

### DIFF
--- a/robocode.ui/src/main/java/net/sf/robocode/ui/battleview/InteractiveHandler.java
+++ b/robocode.ui/src/main/java/net/sf/robocode/ui/battleview/InteractiveHandler.java
@@ -110,7 +110,7 @@ public final class InteractiveHandler implements KeyEventDispatcher, MouseListen
 		int fHeight = battleProps.getBattlefieldHeight();
 
 		if (vWidth < fWidth || vHeight < fHeight) {
-			scale = min((double) vWidth / fWidth, (double) fHeight / fHeight);
+			scale = min((double) vWidth / fWidth, (double) vHeight / fHeight);
 		} else {
 			scale = 1;
 		}
@@ -136,7 +136,7 @@ public final class InteractiveHandler implements KeyEventDispatcher, MouseListen
 		int fHeight = battleProps.getBattlefieldHeight();
 
 		if (vWidth < fWidth || vHeight < fHeight) {
-			scale = min((double) vWidth / fWidth, (double) fHeight / fHeight);
+			scale = min((double) vWidth / fWidth, (double) vHeight / fHeight);
 		} else {
 			scale = 1;
 		}


### PR DESCRIPTION
The bug can be triggered when view height is less than field height, and view width is greater than field width. 
This is caused by a typo in InteractiveHandler. 
