### PR TITLE
add native full screen support for mac

### DIFF
--- a/robocode.ui/src/main/java/net/sf/robocode/ui/dialog/RobocodeFrame.java
+++ b/robocode.ui/src/main/java/net/sf/robocode/ui/dialog/RobocodeFrame.java
@@ -31,6 +31,7 @@ import java.awt.event.*;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.List;
 
@@ -533,6 +534,14 @@ public class RobocodeFrame extends JFrame {
 	 * Initialize the class.
 	 */
 	private void initialize() {
+		try {
+			Class<?> util = Class.forName("com.apple.eawt.FullScreenUtilities");
+			Method method = util.getMethod("setWindowCanFullScreen", Window.class, Boolean.TYPE);
+			method.invoke(util, this, true);
+		} catch (Exception ignore) {
+			// no full screen support
+		}
+
 		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		setTitle("Robocode");
 		setIconImage(ImageUtil.getImage("/net/sf/robocode/ui/icons/robocode-icon.png"));


### PR DESCRIPTION
It will be very convenient for mac users to have native full screen support, this commit managed to do that. Other platforms should be unaffected as the reflection will fall. 

Fullscreen support on mac enables the "fullscreen button" on tittle bar, which is a standard practice of mac apps. 