### PR TITLE
No need to rebuild robot repository from scratch when dev dir is changed

### DIFF
--- a/robocode.repository/src/main/java/net/sf/robocode/repository/RepositoryManager.java
+++ b/robocode.repository/src/main/java/net/sf/robocode/repository/RepositoryManager.java
@@ -472,7 +472,7 @@ public class RepositoryManager implements IRepositoryManager { // NO_UCD (use de
 
 				if (lastEnabledDevelPaths == null || !enabledDevelPaths.equals(lastEnabledDevelPaths)) {
 					lastEnabledDevelPaths = enabledDevelPaths;
-					reload(true);
+					reload(false);
 				}
 			}
 		}


### PR DESCRIPTION
The change in repository roots is properly handled in RepositoryManager.update, rebuilding robot repository from scratch whenever dev dir is changed from Preference dialog is unnecessary and causes significant delay when the repo is large. 

Currently the only workaround to this unwanted behavior is to edit robocode.properties by hand, leaving development options in preference dialog useless. 

All this patch do is toggle a flag that tells reload whether to erase existing content. When set to false, only changed directory will be updated, e.g. removing bots from deleted dev dir, which fits this scenario perfectly. 

See also: [Bug 409](https://sourceforge.net/p/robocode/bugs/409/)