### PR TITLE
fix javadoc gen on java 11

### DIFF
--- a/plugins/testing/robocode.testing.api/pom.xml
+++ b/plugins/testing/robocode.testing.api/pom.xml
@@ -52,6 +52,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 						<link>http://junit.sourceforge.net/javadoc</link>
 						<link>https://robocode.sourceforge.io/docs/robocode</link>
 					</links>
+					<source>6</source>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/robocode.api/pom.xml
+++ b/robocode.api/pom.xml
@@ -46,6 +46,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 					<use>false</use>
 					<excludePackageNames>robocode.exception:net.sf.robocode:gl4java:robocode.robocodeGL</excludePackageNames>
 					<additionalparam>${javadoc.additionalparam}</additionalparam>
+					<source>6</source>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
source java version is supplied
this is necessary for building robocode on java 11