### PR TITLE
Bug-414 - ramming: when robots collide, move bounding box too

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
@@ -1029,6 +1029,7 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 					currentCommands.setDistanceRemaining(0);
 					x -= movedx;
 					y -= movedy;
+					updateBoundingBox();
 
 					boolean teamFire = (teamPeer != null && teamPeer == otherRobot.teamPeer);
 

--- a/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestDuplicatesAndScore.java
+++ b/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestDuplicatesAndScore.java
@@ -141,24 +141,24 @@ public class TestDuplicatesAndScore extends RobocodeTestBed {
 
 		Assert.assertThat(results[0].getRamDamage(), is(0));
 		Assert.assertThat(results[1].getRamDamage(), is(11));
-		Assert.assertThat(results[2].getRamDamage(), is(19));
+		Assert.assertThat(results[2].getRamDamage(), is(24));
 		Assert.assertThat(results[3].getRamDamage(), is(1));
 
 		Assert.assertThat(results[0].getBulletDamageBonus(), is(67));
 		Assert.assertThat(results[1].getBulletDamageBonus(), is(0));
-		Assert.assertThat(results[2].getBulletDamageBonus(), is(0));
+		Assert.assertThat(results[2].getBulletDamageBonus(), is(28));
 		Assert.assertThat(results[3].getBulletDamageBonus(), is(2));
 
 		Assert.assertThat(results[0].getBulletDamage(), is(434));
 		Assert.assertThat(results[1].getBulletDamage(), is(300));
-		Assert.assertThat(results[2].getBulletDamage(), is(220));
+		Assert.assertThat(results[2].getBulletDamage(), is(266));
 		Assert.assertThat(results[3].getBulletDamage(), is(103));
 
-		Assert.assertThat(results[0].getScore(), is(901));
+		Assert.assertThat(results[0].getScore(), is(851));
 		Assert.assertThat(results[1].getScore(), is(661));
-		Assert.assertThat(results[2].getScore(), is(489));
+		Assert.assertThat(results[2].getScore(), is(618));
 		Assert.assertThat(results[3].getScore(), is(257));
 
-		Assert.assertThat(lastTurn, is(4574));
+		Assert.assertThat(lastTurn, is(4809));
 	}
 }

--- a/versions.md
+++ b/versions.md
@@ -1,9 +1,10 @@
-## Version 1.9.4.1 (28-02-2021)
+## Version 1.9.4.1 (24-03-2021)
 
 ### Changes
-* Improve testability: 
+* [Bug-414][] Fixed bug in ramming: when robots collide, they should and do change position. But the bullets were still hitting original place in the next turn, as if the robot was not moved by collision.
 * RoundStartedEvent.getRobotObjects()
-* moved robocode.control.RobotTestBed
+* Improve testability: 
+	* moved robocode.control.RobotTestBed
 	* improved Robot and Bullet toString() so that it displays approximate cardinal direction, like N,NE,E,SE,S,SW,W,NW
 
 ## Version 1.9.4.0 (15-02-2021)
@@ -3156,6 +3157,7 @@ Currently, there is one known issue, which will be fixed with the next Beta or i
 [Bug-409]: http://sourceforge.net/p/robocode/bugs/409/  (Robot repository is completely rebuilt whenever dev dir is changed via UI)
 [Bug-410]: http://sourceforge.net/p/robocode/bugs/410/  (setColors methods warn that they can be called only once per battle, but it's not true)
 [Bug-412]: http://sourceforge.net/p/robocode/bugs/412/  (Bug fix 388 breaks score display in robot buttons)
+[Bug-414]:https://sourceforge.net/p/robocode/bugs/414/  (when robots collide they change position, but the bullets are hitting original place in the next turn)
 
 [Req-1]:   http://sourceforge.net/p/robocode/feature-requests/1/    (Multiple or hyperthreading CPUs (most P4s) hangs Robocode)
 [Req-2]:   http://sourceforge.net/p/robocode/feature-requests/2/    (Keep window size of "New battle" window)


### PR DESCRIPTION
Fixed bug in ramming: when robots collide, they should and do change position. 
But the bullets were still hitting original place in the next turn, as if the robot was not moved by collision.