### PR TITLE
Fix robot naming to be compatible with existing robots

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/peer/RobotPeer.java
@@ -142,7 +142,7 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 	private final BoundingRectangle boundingBox;
 	private final RbSerializer rbSerializer;
 
-	public RobotPeer(Battle battle, IHostManager hostManager, RobotSpecification robotSpecification, TeamPeer team, int robotIndex) {
+	public RobotPeer(Battle battle, IHostManager hostManager, RobotSpecification robotSpecification, String name, String suffix, TeamPeer team, int robotIndex) {
 		super();
 
 		this.battle = battle;
@@ -176,7 +176,7 @@ public final class RobotPeer implements IRobotPeerBattle, IRobotPeer {
 			teamIndex = team.getTeamIndex();
 		}
 
-		this.statics = new RobotStatics(robotSpecification, isTeamLeader, battleRules, teamName, teamMembers,
+		this.statics = new RobotStatics(robotSpecification, name, suffix, isTeamLeader, battleRules, teamName, teamMembers,
 				robotIndex, teamIndex);
 		this.statistics = new RobotStatistics(this, battle.getRobotsCount());
 

--- a/robocode.core/src/main/java/net/sf/robocode/host/RobotStatics.java
+++ b/robocode.core/src/main/java/net/sf/robocode/host/RobotStatics.java
@@ -56,7 +56,7 @@ public final class RobotStatics implements IRobotStatics, Serializable {
 	private final int robotIndex;
 	private final int teamIndex;
 
-	public RobotStatics(RobotSpecification robotSpecification, boolean isLeader, BattleRules rules, String teamName,
+	public RobotStatics(RobotSpecification robotSpecification, String name, String suffix, boolean isLeader, BattleRules rules, String teamName,
 			List<String> teamMembers, int robotIndex, int teamIndex) {
 		IRobotItem robotItem = (IRobotItem) HiddenAccess.getFileSpecification(robotSpecification);
 
@@ -66,8 +66,7 @@ public final class RobotStatics implements IRobotStatics, Serializable {
 		this.shortClassName = robotItem.getShortClassName();
 		this.fullClassName = robotItem.getFullClassName();
 
-		String suffix = " (" + (robotIndex + 1) + ")";
-		this.name = robotItem.getUniqueFullClassNameWithVersion() + suffix;
+		this.name = name;
 		this.shortName = robotItem.getUniqueShortClassNameWithVersion() + suffix;
 		this.veryShortName = robotItem.getUniqueVeryShortClassNameWithVersion() + suffix;
 

--- a/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestDuplicatesAndScore.java
+++ b/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestDuplicatesAndScore.java
@@ -121,18 +121,18 @@ public class TestDuplicatesAndScore extends RobocodeTestBed {
 		Assert.assertNotNull(results);
 		Assert.assertNotNull(robots);
 		Assert.assertThat(robots[0].getName(), is("sample.Fire (1)"));
-		Assert.assertThat(robots[1].getName(), is("sampleteam.MyFirstLeader (2)"));
-		Assert.assertThat(robots[2].getName(), is("sampleteam.MyFirstDroid (3)"));
-		Assert.assertThat(robots[3].getName(), is("sample.Fire (4)"));
-		Assert.assertThat(robots[4].getName(), is("sampleteam.MyFirstLeader (5)"));
-		Assert.assertThat(robots[5].getName(), is("sampleteam.MyFirstDroid (6)"));
-		Assert.assertThat(robots[6].getName(), is("sample.Fire (7)"));
-		Assert.assertThat(robots[7].getName(), is("sample.Crazy (8)"));
+		Assert.assertThat(robots[1].getName(), is("sampleteam.MyFirstLeader (1)"));
+		Assert.assertThat(robots[2].getName(), is("sampleteam.MyFirstDroid (1)"));
+		Assert.assertThat(robots[3].getName(), is("sample.Fire (2)"));
+		Assert.assertThat(robots[4].getName(), is("sampleteam.MyFirstLeader (2)"));
+		Assert.assertThat(robots[5].getName(), is("sampleteam.MyFirstDroid (2)"));
+		Assert.assertThat(robots[6].getName(), is("sample.Fire (3)"));
+		Assert.assertThat(robots[7].getName(), is("sample.Crazy"));
 
 		Assert.assertThat(results[0].getTeamLeaderName(), is("tested.robots.TestTeam (2)"));
 		Assert.assertThat(results[1].getTeamLeaderName(), is("tested.robots.TestTeam (1)"));
 		Assert.assertThat(results[2].getTeamLeaderName(), is("sample.Fire (1)"));
-		Assert.assertThat(results[3].getTeamLeaderName(), is("sample.Crazy (8)"));
+		Assert.assertThat(results[3].getTeamLeaderName(), is("sample.Crazy"));
 
 		Assert.assertThat(results[0].getLastSurvivorBonus(), is(100));
 		Assert.assertThat(results[1].getLastSurvivorBonus(), is(0));

--- a/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestFileAttack.java
+++ b/robocode.tests/src/test/java/net/sf/robocode/test/robots/TestFileAttack.java
@@ -33,15 +33,15 @@ public class TestFileAttack extends RobocodeTestBed {
 		super.onTurnEnded(event);
 		final String out = event.getTurnSnapshot().getRobots()[0].getOutputStreamSnapshot();
 
-		if (out.contains("Preventing tested.robots.FileAttack (1) from access: (java.io.FilePermission C:\\MSDOS.SYS read)")
+		if (out.contains("Preventing tested.robots.FileAttack from access: (java.io.FilePermission C:\\MSDOS.SYS read)")
 				|| out.contains(
-						"Preventing tested.robots.FileAttack (1) from access: (\"java.io.FilePermission\" \"C:\\MSDOS.SYS\" \"read\")")) {
+						"Preventing tested.robots.FileAttack from access: (\"java.io.FilePermission\" \"C:\\MSDOS.SYS\" \"read\")")) {
 			messagedRead = true;
 		}
 		if (out.contains(
-				"Preventing tested.robots.FileAttack (1) from access: (java.io.FilePermission C:\\Robocode.attack write)")
+				"Preventing tested.robots.FileAttack from access: (java.io.FilePermission C:\\Robocode.attack write)")
 						|| out.contains(
-								"Preventing tested.robots.FileAttack (1) from access: (\"java.io.FilePermission\" \"C:\\Robocode.attack\" \"write\")")) {
+								"Preventing tested.robots.FileAttack from access: (\"java.io.FilePermission\" \"C:\\Robocode.attack\" \"write\")")) {
 			messagedWrite = true;
 		}
 	}


### PR DESCRIPTION
This is a possible fix to make getName() compatible with the conventions expected by existing robots again, while also preserving the benefits of recent bug fixes.

Some principles followed in this code to avoid future recurrence of bugs similar to what have existed in the past:
- Never ever duplicate coming up with the suffix string, as that carries risk of becoming out of sync.
- Never ever duplicate how you derive the robot name, as that also carries risk of becoming out of sync.

The second point is why the name derived in Battle.createPeers() gets passed through to RobotStatics() despite the latter having sufficient information to easily derive the name on it's own. As a matter of principle, it seems like best practice to avoid unnecessarily duplicating the derivation of such an important value that needs to match between RobotPeer and TeamPeer, even if it's so simple to derive.

I will note, one underlying source of some of the awkwardness is that RobotStatics' constructor requires TeamPeer's memberNames already be finished, even before all of the RobotPeers are added to it. I had started considering one way of simplifying Battle.createPeers() to be 2 loops instead of 4, however that required removing the "memberNames" list from the TeamPeer constructor, and instead populate the list based on having TeamPeer.add() call RobotPeer.getName(). Unfortunately, this approach ran up against a problem with the RobotStatics() constructor requiring TeamPeer's "memberNames" list to already be fully populated. If populating the "teammates" array in RobotStatics could be deferred until after all RobotPeers are constructed and added to their corresponding TeamPeers, it would allow simplifying Battle.createPeers(), however it appears that would also require deferring IHostingRobotProxy.createRobotProxy to be after that rather than at RobotPeer constructor time... and that all started looking like surgery that would be going too deep for my tastes at this time :-)

As of this moment I've not added extra tests or extended existing tests for this, but may consider that.