### PR TITLE
Installer (dos2unix): more reliable way to move files

### DIFF
--- a/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
+++ b/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
@@ -801,8 +801,6 @@ public class AutoExtract implements ActionListener {
             }
         }
 
-        if (new File(filepath).delete()) {
-            tempFile.renameTo(new File(filepath));
-        }
+        Files.move(tempFile.toPath(), Paths.get(filepath), StandardCopyOption.REPLACE_EXISTING);
     }
 }


### PR DESCRIPTION
**Problem:**
Shellscripts may not appear in the installation directory.

**Cause:**
The temporary directory and the installation directory may be on different file systems.
See: https://docs.oracle.com/javase/7/docs/api/java/io/File.html#renameTo(java.io.File)