### PR TITLE
Give bots without rank highest priority

### DIFF
--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/PrepareBattles.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/PrepareBattles.java
@@ -13,6 +13,7 @@ import static net.sf.robocode.roborumble.util.PropertiesUtil.getProperties;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
@@ -259,7 +260,7 @@ public class PrepareBattles {
 		int count = 0;
 
 		// Add priority battles
-		while (count < numbattles && count < priorityBattles.size()) {
+		while (count < numbattles - namesNoRanking.size() && count < priorityBattles.size()) {
 			String battle = priorityBattles.get(count);
 
 			String[] items = battle.split(",");

--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/PrepareBattles.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/battlesengine/PrepareBattles.java
@@ -13,7 +13,6 @@ import static net.sf.robocode.roborumble.util.PropertiesUtil.getProperties;
 
 import java.io.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;


### PR DESCRIPTION
Currently priority battles from server has higher priority than bots without rank, this is a bug, because the server never knows those bots and never give them priority. 

This bug causes the client to continuously running bots that already have rank, but leave the bots without rank still without rank, and never get to a stable state. 