### PR TITLE
Fix bug-418 that excluded bots are removed from LiteRumble

### DIFF
--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/util/ExcludesUtil.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/util/ExcludesUtil.java
@@ -61,6 +61,9 @@ public class ExcludesUtil {
 			return false;
 		}
 
+		// Fix bug-418, excluded bots are removed from LiteRumble
+		botNameVersion = botNameVersion.replace('_', ' ');
+
 		// Check the name against all exclude filters
 		for (int i = excludes.length - 1; i >= 0; i--) {
 			try {


### PR DESCRIPTION
`isExcluded` receives either space separated form (e.g. xyz.FirstRobot 1.0) and underscore separated form (e.g. xyz.FirstRobot_1.0). If the former form is marked as excluded, the latter form will not be considered as excluded, triggering a bug and causing the removal of the participant. If the latter form is marked as excluded, there will be no effect. 

The bug fix is to forcefully normalize the `botNameVersion` parameter of `isExcluded`, avoiding the unintended removal of the excluded bots from the LiteRumble. 