### PR TITLE
Fix  truncated battles on attempted thread stop

### DIFF
--- a/robocode.host/src/main/java/net/sf/robocode/host/security/RobotThreadManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/security/RobotThreadManager.java
@@ -94,11 +94,11 @@ public class RobotThreadManager {
 	 */
 	public boolean waitForStop() {
 		boolean isAlive = false;
-
-		if (runThread != null && runThread.isAlive()) {
-			runThread.interrupt();
-			waitForStop(runThread);
-			isAlive = runThread.isAlive();
+        Thread thr = runThread; // forceStop() can set to null concurrently
+		if (thr != null && thr.isAlive()) {
+			thr.interrupt();
+			waitForStop(thr);
+			isAlive = thr.isAlive();
 		}
 
 		Thread[] threads = new Thread[100];
@@ -108,7 +108,7 @@ public class RobotThreadManager {
 		}
 
 		for (Thread thread : threads) {
-			if (thread != null && thread != runThread && thread.isAlive()) {
+			if (thread != null && thread != thr && thread.isAlive()) {
 				thread.interrupt();
 				waitForStop(thread);
 				isAlive |= thread.isAlive();


### PR DESCRIPTION
I found an issue with the new security manager. If the thread stop fails there is a NPE which ends up aborting the battle early. This causes battles to be reported with their results, but the wrong number of rounds.

The fix is to take a reference to the thread beforehand so that we don't throw the NPE when the forceStop() sets it to null.