### PR TITLE
Make URLJarCollector tolerant of JDK 21 (and newer JVMs)

### DIFF
--- a/robocode.core/src/main/java/net/sf/robocode/io/URLJarCollector.java
+++ b/robocode.core/src/main/java/net/sf/robocode/io/URLJarCollector.java
@@ -59,8 +59,9 @@ public class URLJarCollector {
 			jarFileURL = jarURLConnection.getDeclaredField("jarFileURL");
 			jarFileURL.setAccessible(true);
 
-			localSunJVM = true;
-		} catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException ignore) {
+			localSunJVM = (fileCache != null && urlCache != null);
+		} catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException | RuntimeException ignore) {
+			// Not a classic SUN/Oracle JVM layout: fall back to the non-caching path.
 		}
 		sunJVM = localSunJVM;
 


### PR DESCRIPTION
## Summary

This change hardens the static initializer in
`robocode.core/src/main/java/net/sf/robocode/io/URLJarCollector.java` so Robocode
runs correctly on **JDK 21** and other modern JVMs where the internal
`sun.net.www.protocol.jar.*` layout differs from the classic Sun/Oracle JVM.

## Problem

`URLJarCollector` reflects into the JDK-internal classes
`sun.net.www.protocol.jar.JarFileFactory` and
`sun.net.www.protocol.jar.JarURLConnection` to enable a fast, caching JAR
connection path. On JDK 21:

- The reflective access into these internal classes can fail with a
  `RuntimeException` (e.g. `InaccessibleObjectException` from the module system),
  which was **not** caught by the previous `catch` clause.
- Even when the fields resolve, `fileCache` / `urlCache` may not be in the shape
  the caching path assumes.

Because the previous code only caught the checked reflection exceptions
(`ClassNotFoundException | NoSuchFieldException | IllegalAccessException`), any
`RuntimeException` thrown during initialization escaped the `static` block and
prevented the class from loading.

## Fix

- Treat the JVM as a "classic Sun/Oracle JVM" (`sunJVM = true`) only when both
  `fileCache` and `urlCache` were successfully resolved to non-null values,
  rather than assuming success after the reflection calls.
- Also catch `RuntimeException` so unexpected failures (such as the module-system
  access errors seen on JDK 21) gracefully fall back to the non-caching code path
  instead of failing class initialization.

When the JVM is not recognized, `openConnection` simply disables URL caching
(`urlConnection.setUseCaches(false)`), which is the correct, portable behavior.
