### PR TITLE
Do not enforce 0-99 priority rule on system events

### DIFF
--- a/robocode.api/src/main/java/robocode/Event.java
+++ b/robocode.api/src/main/java/robocode/Event.java
@@ -170,6 +170,13 @@ public abstract class Event implements Comparable<Event>, Serializable {
 	 */
 	// This method must be invisible on Robot API
 	private void setPriorityHidden(int newPriority) {
+		// System events have a fixed priority (e.g. 100) that is outside the 0-99 range allowed for
+		// robot-defined events. The priority of a system event must not be changed, and the 0-99 rule
+		// must not be enforced for them, as that would clamp their priority and emit misleading
+		// warnings on the robot console.
+		if (isCriticalEvent()) {
+			return;
+		}
 		if (newPriority < 0) {
 			Logger.printlnToRobotsConsole("SYSTEM: Priority must be between 0 and 99");
 			Logger.printlnToRobotsConsole("SYSTEM: Priority for " + this.getClass().getName() + " will be 0");

--- a/robocode.host/src/main/java/net/sf/robocode/host/events/EventManager.java
+++ b/robocode.host/src/main/java/net/sf/robocode/host/events/EventManager.java
@@ -510,6 +510,7 @@ public final class EventManager implements IEventManager {
 		}
 		if (HiddenAccess.isCriticalEvent(event)) {
 			robotProxy.println("SYSTEM: You may not change the priority of a system event.");
+			return;
 		}
 		HiddenAccess.setEventPriority(event, priority);
 	}


### PR DESCRIPTION
## Problem

System events (`WinEvent`, `BattleEndedEvent`, `SkippedTurnEvent`, `RoundEndedEvent`, `DeathEvent`) have a fixed priority of `100`, which is outside the `0-99` range allowed for robot-defined events. When the engine (or tooling that reconstructs events) stamps such an event with its per-class default priority, `Event.setPriorityHidden()` clamped it to 99 and printed misleading noise to the robot console:

```SYSTEM: Priority must be between 0 and 99
SYSTEM: Priority for robocode.WinEvent will be 99
```
## Fix

- `Event.setPriorityHidden()` now returns early for critical (system) events, leaving their priority untouched and emitting no warning. System events already override `getPriority()` to return their fixed value, so the unset field is never consulted.
- `EventManager.setEventPriority()` now returns after warning a robot that it may not change a system event's priority, so the request is genuinely ignored (previously it fell through and applied/clamped the value).

## Security

`isCriticalEvent()` is package-private to `robocode` and the robot class loader refuses to define any `robocode.*` class from robot bytes (delegating to the trusted parent loader regardless of the security flag), so robots cannot override it to abuse this path.