### PR TITLE
Update literumble URLs to rumble.robowiki.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Happy Robocoding! 🤖⌨️
 
 [Robocode Tank Royale]: https://github.com/robocode-dev/tank-royale "Robocode Tank Royale"
 
-[LiteRumble]: https://literumble.appspot.com/ "LiteRumble - Robocode competitive rankings"
+[LiteRumble]: https://rumble.robowiki.net/ "LiteRumble - Robocode competitive rankings"

--- a/robocode.content/src/main/resources/ReadMe.html
+++ b/robocode.content/src/main/resources/ReadMe.html
@@ -139,7 +139,7 @@
 </ul>
 <h3 id="robocode-repository">ROBOCODE REPOSITORY</h3>
 <p>If you want to try out new robots other than the sample robots that come with Robocode, you should visit the
-    <a href="https://literumble.appspot.com/">LiteRumble home</a> that contains lots of bots.</p>
+    <a href="https://rumble.robowiki.net/">LiteRumble home</a> that contains lots of bots.</p>
 <h3 id="community">COMMUNITY</h3>
 <p>The community around Robocode is using the <a href="https://robowiki.net/">RoboWiki</a> as a communication channel. At the
     RoboWiki, people share new ideas, code snippets, algorithms, strategies, and lots of other stuff about Robocode. New
@@ -172,7 +172,7 @@
 <h3 id="enter-the-competition">ENTER THE COMPETITION</h3>
 <p>If you want to challenge your robot(s) and yourself as Robocoder, the <a href="https://robowiki.net/wiki/LiteRumble">LiteRumble</a>
     is the best way to do it. LiteRumble is the ultimate collaborative effort to have a live,
-    <a href="https://literumble.appspot.com/">up-to-date ranking</a> of Robocode bots.</p>
+    <a href="https://rumble.robowiki.net/">up-to-date ranking</a> of Robocode bots.</p>
 <p>So don&#39;t hesitate to <a href="https://robowiki.net/wiki/RoboRumble/Enter_The_Competition">enter the RoboRumble competition</a>.</p>
 <h3 id="command-line">COMMAND LINE</h3>
 <p>It is possible to specify options and predefined properties from the command-line when running Robocode. The usage of
@@ -214,7 +214,7 @@
 <p>A feature request should be put on the <a href="https://sourceforge.net/p/robocode/feature-requests/">Feature Requests</a> on the
     SourceForge site for Robocode. Each feature request will be prioritized among other feature requests.</p>
 <p>Note that if the feature is a big change to the game, e.g. change the robot behaviour, it might not be accepted, as
-    Robocode is being used for competitions like e.g. the <a href="https://literumble.appspot.com/">LiteRumble</a>.</p>
+    Robocode is being used for competitions like e.g. the <a href="https://rumble.robowiki.net/">LiteRumble</a>.</p>
 <p>It will be a great help if you describe your idea in detail, and how you think it could be implemented into Robocode.
     For example, will it be possible to extend an existing feature with your idea?</p>
 <p>If you are a registered user at SourceForge (register <a href="https://sourceforge.net/user/registration">here</a> you will be able

--- a/robocode.content/src/main/resources/ReadMe.md
+++ b/robocode.content/src/main/resources/ReadMe.md
@@ -166,7 +166,7 @@ The Robocode API consists of several APIs.
 ### ROBOCODE REPOSITORY
 
 If you want to try out new robots other than the sample robots that come with Robocode, you should visit the
-[LiteRumble home](https://literumble.appspot.com/) that contains lots of bots.
+[LiteRumble home](https://rumble.robowiki.net/) that contains lots of bots.
 
 ### COMMUNITY
 
@@ -205,7 +205,7 @@ But there is a lot of other challenges available on RoboWiki besides the ones li
 
 If you want to challenge your robot(s) and yourself as Robocoder, the [LiteRumble](https://robowiki.net/wiki/LiteRumble)
 is the best way to do it. LiteRumble is the ultimate collaborative effort to have a live,
-[up-to-date ranking](https://literumble.appspot.com/) of Robocode bots.
+[up-to-date ranking](https://rumble.robowiki.net/) of Robocode bots.
 
 So don't hesitate to [enter the RoboRumble competition](https://robowiki.net/wiki/RoboRumble/Enter_The_Competition).
 
@@ -261,7 +261,7 @@ A feature request should be put on the [Feature Requests](https://sourceforge.ne
 SourceForge site for Robocode. Each feature request will be prioritized among other feature requests.
 
 Note that if the feature is a big change to the game, e.g. change the robot behaviour, it might not be accepted, as
-Robocode is being used for competitions like e.g. the [LiteRumble](https://literumble.appspot.com/).
+Robocode is being used for competitions like e.g. the [LiteRumble](https://rumble.robowiki.net/).
 
 It will be a great help if you describe your idea in detail, and how you think it could be implemented into Robocode.
 For example, will it be possible to extend an existing feature with your idea?

--- a/robocode.content/src/main/resources/roborumble/meleerumble.txt
+++ b/robocode.content/src/main/resources/roborumble/meleerumble.txt
@@ -130,7 +130,7 @@ PARTICIPANTSFILE=./roborumble/files/participmelee.txt
 
 STARTAG=pre
 
-UPDATEBOTSURL=https://literumble.appspot.com/RemoveOldParticipant
+UPDATEBOTSURL=https://rumble.robowiki.net/RemoveOldParticipant
 
 #-------------------------------------------------------------------------------
 # Properties to control the way battles are run
@@ -190,7 +190,7 @@ PRIORITYBATTLESFILE=./roborumble/temp/prioritymelee.txt
 #           File containing the number of battles fought by the robots, which is
 #           returned by the server when results are uploaded to the server.
 
-RESULTSURL=https://literumble.appspot.com/UploadedResults
+RESULTSURL=https://rumble.robowiki.net/UploadedResults
 
 BATTLESNUMFILE=./roborumble/temp/meleebattlesnumber.txt
 
@@ -236,7 +236,7 @@ CODESIZEFILE=./roborumble/files/codesizemelee.txt
 # RATINGS.NANOBOTS:
 #           File name for the rating file of the Melee NanoRumble.
 
-RATINGS.URL=https://literumble.appspot.com/RatingsFile
+RATINGS.URL=https://rumble.robowiki.net/RatingsFile
 
 RATINGS.GENERAL=./roborumble/temp/ratings_m_roborumble.txt
 RATINGS.MINIBOTS=./roborumble/temp/ratings_m_minirumble.txt

--- a/robocode.content/src/main/resources/roborumble/roborumble.txt
+++ b/robocode.content/src/main/resources/roborumble/roborumble.txt
@@ -127,7 +127,7 @@ PARTICIPANTSFILE=./roborumble/files/particip1v1.txt
 
 STARTAG=pre
 
-UPDATEBOTSURL=https://literumble.appspot.com/RemoveOldParticipant
+UPDATEBOTSURL=https://rumble.robowiki.net/RemoveOldParticipant
 
 #-------------------------------------------------------------------------------
 # Properties to control the way battles are run
@@ -187,7 +187,7 @@ PRIORITYBATTLESFILE=./roborumble/temp/priority1v1.txt
 #           File containing the number of battles fought by the robots, which is
 #           returned by the server when results are uploaded to the server.
 
-RESULTSURL=https://literumble.appspot.com/UploadedResults
+RESULTSURL=https://rumble.robowiki.net/UploadedResults
 
 BATTLESNUMFILE=./roborumble/temp/battlesnumber.txt
 
@@ -233,7 +233,7 @@ CODESIZEFILE=./roborumble/files/codesize1v1.txt
 # RATINGS.NANOBOTS:
 #           File name for the rating file of the NanoRumble.
 
-RATINGS.URL=https://literumble.appspot.com/RatingsFile
+RATINGS.URL=https://rumble.robowiki.net/RatingsFile
 
 RATINGS.GENERAL=./roborumble/temp/ratings_roborumble.txt
 RATINGS.MINIBOTS=./roborumble/temp/ratings_minirumble.txt

--- a/robocode.content/src/main/resources/roborumble/teamrumble.txt
+++ b/robocode.content/src/main/resources/roborumble/teamrumble.txt
@@ -127,7 +127,7 @@ PARTICIPANTSFILE=./roborumble/files/participTeams.txt
 
 STARTAG=pre
 
-UPDATEBOTSURL=https://literumble.appspot.com/RemoveOldParticipant
+UPDATEBOTSURL=https://rumble.robowiki.net/RemoveOldParticipant
 
 #-------------------------------------------------------------------------------
 # Properties to control the way battles are run
@@ -175,7 +175,7 @@ PRIORITYBATTLESFILE=./roborumble/temp/priorityTeams.txt
 #           File containing the number of battles fought by the robots, which is
 #           returned by the server when results are uploaded to the server.
 
-RESULTSURL=https://literumble.appspot.com/UploadedResults
+RESULTSURL=https://rumble.robowiki.net/UploadedResults
 
 BATTLESNUMFILE=./roborumble/temp/teambattlesnumber.txt
 
@@ -198,6 +198,6 @@ BATTLESNUMFILE=./roborumble/temp/teambattlesnumber.txt
 # RATINGS.NANOBOTS:
 #           File name for the rating file of the NanoRumble.
 
-RATINGS.URL=https://literumble.appspot.com/RatingsFile
+RATINGS.URL=https://rumble.robowiki.net/RatingsFile
 
 RATINGS.GENERAL=./roborumble/temp/ratings_teamrumble.txt

--- a/robocode.content/src/main/resources/roborumble/twinduel.txt
+++ b/robocode.content/src/main/resources/roborumble/twinduel.txt
@@ -127,7 +127,7 @@ PARTICIPANTSFILE=./roborumble/files/participTwinduel.txt
 
 STARTAG=pre
 
-UPDATEBOTSURL=https://literumble.appspot.com/RemoveOldParticipant
+UPDATEBOTSURL=https://rumble.robowiki.net/RemoveOldParticipant
 
 #-------------------------------------------------------------------------------
 # Properties to control the way battles are run
@@ -175,7 +175,7 @@ PRIORITYBATTLESFILE=./roborumble/temp/priorityTwinduel.txt
 #           File containing the number of battles fought by the robots, which is
 #           returned by the server when results are uploaded to the server.
 
-RESULTSURL=https://literumble.appspot.com/UploadedResults
+RESULTSURL=https://rumble.robowiki.net/UploadedResults
 
 BATTLESNUMFILE=./roborumble/temp/twinduelbattlesnumber.txt
 
@@ -198,6 +198,6 @@ BATTLESNUMFILE=./roborumble/temp/twinduelbattlesnumber.txt
 # RATINGS.NANOBOTS:
 #           File name for the rating file of the NanoRumble.
 
-RATINGS.URL=https://literumble.appspot.com/RatingsFile
+RATINGS.URL=https://rumble.robowiki.net/RatingsFile
 
 RATINGS.GENERAL=./roborumble/temp/ratings_twinduel.txt


### PR DESCRIPTION
I have migrated literumble off of appengine, onto the same VPS hosting the robowiki. This updates the URLs in the readme and rumble clients.